### PR TITLE
implementing null and length on Data.LinearRing and Data.LineString for improved performance

### DIFF
--- a/src/Data/LineString.hs
+++ b/src/Data/LineString.hs
@@ -172,6 +172,11 @@ instance Foldable LineString where
   --  foldr :: (a -> b -> b) -> b -> LineString a -> b
   foldr f u (LineString x y zs) = f x (f y (Foldable.foldr f u zs))
 
+  -- we implement these methods for improved performance
+  null _ = False
+  length (LineString _ _ zs) = 2 + Sequence.length zs
+
+
 instance Traversable LineString where
   --  sequenceA :: (Traversable t, Applicative f) => t (f a) -> f (t a)
   sequenceA (LineString fx fy fzs) = LineString <$> fx <*> fy <*> sequenceA fzs

--- a/src/Data/LinearRing.hs
+++ b/src/Data/LinearRing.hs
@@ -200,6 +200,10 @@ instance Foldable LinearRing where
   --  foldr :: (a -> b -> b) -> b -> LinearRing a -> b
   foldr f u (LinearRing x y z ws) = f x (f y (f z (Foldable.foldr f (f x u) ws)))
 
+  -- we implement these methods for improved performance
+  null _ = False
+  length (LinearRing _ _ _ ws) = 3 + Sequence.length ws
+
 -- |
 -- When traversing this Structure, the Applicative context
 -- of the last element will be appended to the end to close the loop

--- a/src/Data/LinearRing.hs
+++ b/src/Data/LinearRing.hs
@@ -202,7 +202,7 @@ instance Foldable LinearRing where
 
   -- we implement these methods for improved performance
   null _ = False
-  length (LinearRing _ _ _ ws) = 3 + Sequence.length ws
+  length (LinearRing _ _ _ ws) = 4 + Sequence.length ws
 
 -- |
 -- When traversing this Structure, the Applicative context


### PR DESCRIPTION
as the title says. In particular the default implementation for length is O(n), whereas O(log n) suffices.